### PR TITLE
Add missing <optional> header include to widgets

### DIFF
--- a/app/qfontfacereader.h
+++ b/app/qfontfacereader.h
@@ -6,6 +6,7 @@
 #include <QImage>
 #include <memory>
 #include <utility>
+#include <optional>
 
 class QFontFaceReader : public f2b::font::face_reader
 {

--- a/app/ui/facewidget.h
+++ b/app/ui/facewidget.h
@@ -7,6 +7,7 @@
 #include "focuswidget.h"
 
 #include <memory>
+#include <optional>
 
 class GlyphInfoWidget;
 


### PR DESCRIPTION
Hi, great app. I ran into a build issue on my system and subsequently fixed it.

This change seems to be required for the usage of `std::optional`.

g++ (GCC) 11.1.0 / cmake version 3.20.3 / Linux 5.4.124-1-MANJARO