### PR TITLE
Include cstdint in format.h

### DIFF
--- a/lib/src/format.h
+++ b/lib/src/format.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <iostream>
 #include <iomanip>
+#include <cstdint>
 #include "sourcecode.h"
 
 namespace f2b


### PR DESCRIPTION
Was failing to compile on my machine because `format.h` uses types like `uint8_t` but doesn't includes `cstdint`. Now at least compiles with warnings. 